### PR TITLE
✨Feat: 알람 세팅 화면 UI 구현

### DIFF
--- a/RocketCall/Util/BaseCardView.swift
+++ b/RocketCall/Util/BaseCardView.swift
@@ -33,7 +33,7 @@ final class BaseCardView: UIView {
     }
     
     private func setupStyle() {
-        self.backgroundColor = UIColor(red: 18/255.0, green: 26/255.0, blue: 48/255.0, alpha: 1.0)
+        self.backgroundColor = .cardBackground
         self.layer.cornerRadius = 16
         self.layer.masksToBounds = true
         self.layer.borderWidth = 1

--- a/RocketCall/View/AlarmSettingView.swift
+++ b/RocketCall/View/AlarmSettingView.swift
@@ -1,0 +1,236 @@
+//
+//  presentSettingView.swift
+//  RocketCall
+//
+//  Created by 김주희 on 3/23/26.
+//
+
+import UIKit
+import SnapKit
+import Then
+import RxSwift
+import RxCocoa
+
+final class AlarmSettingView: UIView {
+    
+    private let disposeBag = DisposeBag()
+    
+    
+    // MARK: - UI Components
+    private let containerView = BaseCardView()
+    
+    private let titleLabel = UILabel().then {
+        $0.text = "알람 설정"
+        $0.font = .systemFont(ofSize: 26, weight: .bold)
+        $0.textColor = .mainLabel
+    }
+    
+    private let closeButton = UIButton().then {
+        let config = UIImage.SymbolConfiguration(weight: .semibold)
+        $0.setImage(UIImage(systemName: "xmark", withConfiguration: config), for: .normal)
+        $0.tintColor = .mainLabel
+    }
+    
+    private let alarmTimeStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 8
+        $0.alignment = .center
+    }
+    
+    private let watchImage = UIImageView().then {
+        $0.image = UIImage(systemName: "alarm")
+        $0.tintColor = .subPoint
+    }
+    
+    private let alarmTimeLabel = UILabel().then {
+        $0.text = "알람 시간"
+        $0.textColor = .subPoint
+        $0.font = .systemFont(ofSize: 16, weight: .bold)
+    }
+    
+    private let timePickerView = UIDatePicker().then {
+        $0.datePickerMode = .time
+        $0.preferredDatePickerStyle = .wheels
+        $0.overrideUserInterfaceStyle = .dark
+    }
+    
+    private let alarmNameTitle = UILabel().then {
+        $0.font = .systemFont(ofSize: 17, weight: .bold)
+        $0.text = "알람 이름"
+        $0.textColor = .mainLabel
+    }
+    
+    private let alarmTextField = UITextField().then {
+        $0.attributedPlaceholder = NSAttributedString(string: "예: 기상", attributes: [NSAttributedString.Key.foregroundColor: UIColor.subLabel.withAlphaComponent(0.8).cgColor])
+        $0.textColor = .mainLabel
+        $0.layer.cornerRadius = 12
+        $0.layer.borderWidth = 0.5
+        $0.layer.borderColor = UIColor.subLabel.withAlphaComponent(0.6).cgColor
+        
+        // 왼쪽 여백
+        $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 14, height: 40))
+        $0.leftViewMode = .always
+    }
+    
+    private let repeatDayTitleLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 17, weight: .bold)
+        $0.text = "반복 요일"
+        $0.textColor = .mainLabel
+    }
+    
+    private let dayButtonsStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.distribution = .equalSpacing
+        $0.alignment = .center
+        $0.spacing = 8
+    }
+    
+    private func setupDayButtons() {
+        let days = ["월", "화", "수", "목", "금", "토", "일"]
+        
+        for day in days {
+            let button = DayButton(title: day)
+            
+            button.snp.makeConstraints {
+                $0.width.equalTo(38)
+                $0.height.equalTo(50)
+            }
+            dayButtonsStackView.addArrangedSubview(button)
+            
+            button.rx.tap
+                .subscribe(onNext: { [weak button] in
+                    button?.isSelected.toggle()
+                })
+                .disposed(by: disposeBag)
+        }
+    }
+    
+    private let buttonStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.alignment = .center
+        $0.spacing = 15
+        $0.distribution = .fillEqually
+    }
+    
+    private let cancelButton = RectangleButton(title: "취소", color: .subLabel.withAlphaComponent(0.2))
+    private let saveButton = RectangleButton(title: "저장", color: .mainPoint)
+
+    
+    // MARK: - init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        setupDayButtons()
+    }
+    
+    required init?(coder: NSCoder) { fatalError() }
+    
+    
+    // MARK: - setup UI
+    private func setupUI() {
+        containerView.isOn = true
+        
+        self.addSubview(containerView)
+        
+        [titleLabel, closeButton, alarmTimeStackView, timePickerView, alarmNameTitle, alarmTextField, repeatDayTitleLabel, dayButtonsStackView, buttonStackView].forEach { containerView.addSubview($0) }
+        
+        [watchImage, alarmTimeLabel].forEach { alarmTimeStackView.addArrangedSubview($0) }
+        
+        [cancelButton, saveButton].forEach { buttonStackView.addArrangedSubview($0) }
+        
+        containerView.snp.makeConstraints {
+            $0.centerY.equalToSuperview().offset(-40)
+            $0.height.equalTo(590)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(25)
+            $0.leading.equalToSuperview().inset(25)
+        }
+        
+        closeButton.snp.makeConstraints {
+            $0.centerY.equalTo(titleLabel)
+            $0.trailing.equalToSuperview()
+            $0.height.width.equalTo(70)
+        }
+        
+        alarmTimeStackView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(20)
+            $0.centerX.equalToSuperview()
+        }
+        
+        timePickerView.snp.makeConstraints {
+            $0.top.equalTo(alarmTimeStackView.snp.bottom)
+            $0.centerX.equalToSuperview()
+        }
+        
+        alarmNameTitle.snp.makeConstraints {
+            $0.top.equalTo(timePickerView.snp.bottom)
+            $0.leading.equalTo(titleLabel.snp.leading)
+        }
+        
+        alarmTextField.snp.makeConstraints {
+            $0.top.equalTo(alarmNameTitle.snp.bottom).offset(8)
+            $0.leading.equalTo(titleLabel.snp.leading)
+            $0.trailing.equalToSuperview().inset(25)
+            $0.height.equalTo(50)
+        }
+        
+        repeatDayTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(alarmTextField.snp.bottom).offset(25)
+            $0.leading.equalTo(titleLabel.snp.leading)
+        }
+        
+        dayButtonsStackView.snp.makeConstraints {
+            $0.top.equalTo(repeatDayTitleLabel.snp.bottom).offset(8)
+            $0.centerX.equalToSuperview()
+        }
+        
+        buttonStackView.snp.makeConstraints {
+            $0.leading.bottom.trailing.equalToSuperview().inset(25)
+            $0.centerX.equalToSuperview()
+        }
+        
+        cancelButton.snp.makeConstraints {
+            $0.height.equalTo(50)
+        }
+        
+        saveButton.snp.makeConstraints {
+            $0.height.equalTo(cancelButton)
+        }
+    }
+}
+
+
+// MARK: - 요일 버튼
+final class DayButton: UIButton {
+    
+    override var isSelected: Bool {
+        didSet {
+            updateColors()
+        }
+    }
+    
+    init(title: String) {
+        super.init(frame: .zero)
+        
+        self.setTitle(title, for: .normal)
+        self.titleLabel?.font = .systemFont(ofSize: 17, weight: .medium)
+        self.layer.cornerRadius = 12
+        self.layer.masksToBounds = true
+        updateColors()
+    }
+    
+    required init?(coder: NSCoder) { fatalError() }
+    
+    private func updateColors() {
+        if isSelected {
+            self.setTitleColor(.mainPoint, for: .normal)
+            self.backgroundColor = .mainPoint.withAlphaComponent(0.2)
+        } else {
+            self.setTitleColor(.mainLabel, for: .normal)
+            self.backgroundColor = .subLabel.withAlphaComponent(0.2)
+        }
+    }
+}


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #13 

## 🛠 작업 내용 (What I did)
- 알람 추가 및 수정 시 띄울 AlarmSettingView UI를 구현했습니다.

## 💻 구현 상세 (Implementation Details)
- 반복 요일 버튼 (RxSwift): 상태에 따라 색상이 변하는 커스텀 DayButton을 만들었습니다. @objc 함수 대신 RxSwift(rx.tap)를 사용해 버튼을 누를 때마다 상태(색상)가 직관적으로 토글되도록 구현했습니다.

## 📸 스크린샷 (Screenshots)
<img width="600" height="1400" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-25 at 00 18 03" src="https://github.com/user-attachments/assets/ef74abcc-9447-4499-a289-6f7acc5d8eb4" />

## 🧐 리뷰 포인트 (Review Points)
- 뷰 컴포넌트들(특히 요일 버튼들)의 크기나 위아래 간격이 시안과 잘 맞는지, 어색한 부분은 없는지 UI 확인 부탁드립니다!
- 요일 버튼 탭 이벤트를 Rx로 묶어두었는데, 추후 ViewModel의 Input으로 넘기기 좋은 구조인지 가볍게 코드 리뷰해 주시면 감사하겠습니다 🙇‍♀️

## ✅ 자가 점검 (Self Checklist)
- [☑️] 빌드 및 테스트가 정상적으로 통과되었나요?
- [☑️] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [☑️] 불필요한 주석이나 디버그 코드를 삭제했나요?
